### PR TITLE
TopK processor plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 - [#3319](https://github.com/influxdata/telegraf/issues/3319): Fix cloudwatch output requires unneeded permissions.
 - [#3351](https://github.com/influxdata/telegraf/issues/3351): Fix prometheus passthrough for existing value types.
 
-## v1.4.3 [unreleased]
+## v1.4.3 [2017-10-25]
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [#3358](https://github.com/influxdata/telegraf/pull/3358): Add support for decimal timestamps to ts-epoch modifier.
 - [#3337](https://github.com/influxdata/telegraf/pull/3337): Add histogram and summary types and use in prometheus plugins.
 - [#3365](https://github.com/influxdata/telegraf/pull/3365): Gather concurrently from snmp agents.
+- [#3333](https://github.com/influxdata/telegraf/issues/3333): Perform DNS lookup before ping and report result.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [#3350](https://github.com/influxdata/telegraf/pull/3350): Use labels in prometheus output for string fields.
 - [#3358](https://github.com/influxdata/telegraf/pull/3358): Add support for decimal timestamps to ts-epoch modifier.
 - [#3337](https://github.com/influxdata/telegraf/pull/3337): Add histogram and summary types and use in prometheus plugins.
+- [#3365](https://github.com/influxdata/telegraf/pull/3365): Gather concurrently from snmp agents.
 
 ### Bugfixes
 

--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -28,11 +28,14 @@ urls = ["www.google.com"] # required
 - packets_received ( from ping output )
 - percent_reply_loss ( compute from packets_transmitted and reply_received )
 - percent_packets_loss ( compute from packets_transmitted and packets_received )
-- errors ( when host can not be found or wrong prameters is passed to application )
+- errors ( when host can not be found or wrong parameters is passed to application )
 - response time
     - average_response_ms ( compute from minimum_response_ms and maximum_response_ms )
     - minimum_response_ms ( from ping output )
     - maximum_response_ms ( from ping output )
+- result_code
+    - 0: success
+    - 1: no such host
 
 ### Tags:
 
@@ -44,5 +47,5 @@ urls = ["www.google.com"] # required
 ```
 $ ./telegraf --config telegraf.conf --input-filter ping --test
 * Plugin: ping, Collection 1
-ping,host=WIN-PBAPLP511R7,url=www.google.com average_response_ms=7i,maximum_response_ms=9i,minimum_response_ms=7i,packets_received=4i,packets_transmitted=4i,percent_packet_loss=0,percent_reply_loss=0,reply_received=4i 1469879119000000000
+ping,host=WIN-PBAPLP511R7,url=www.google.com result_code=0i,average_response_ms=7i,maximum_response_ms=9i,minimum_response_ms=7i,packets_received=4i,packets_transmitted=4i,percent_packet_loss=0,percent_reply_loss=0,reply_received=4i 1469879119000000000
 ```

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -158,6 +158,7 @@ func TestPingGather(t *testing.T) {
 		"average_response_ms":   43.628,
 		"maximum_response_ms":   51.806,
 		"standard_deviation_ms": 5.325,
+		"result_code":           0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 
@@ -198,6 +199,7 @@ func TestLossyPingGather(t *testing.T) {
 		"average_response_ms":   44.033,
 		"maximum_response_ms":   51.806,
 		"standard_deviation_ms": 5.325,
+		"result_code":           0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 }
@@ -230,6 +232,7 @@ func TestBadPingGather(t *testing.T) {
 		"packets_transmitted": 2,
 		"packets_received":    0,
 		"percent_packet_loss": 100.0,
+		"result_code":         0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 }

--- a/plugins/inputs/ping/ping_windows.go
+++ b/plugins/inputs/ping/ping_windows.go
@@ -4,6 +4,7 @@ package ping
 
 import (
 	"errors"
+	"net"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -158,6 +159,18 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 		wg.Add(1)
 		go func(u string) {
 			defer wg.Done()
+
+			tags := map[string]string{"url": u}
+			fields := map[string]interface{}{"result_code": 0}
+
+			_, err := net.LookupHost(u)
+			if err != nil {
+				errorChannel <- err
+				fields["result_code"] = 1
+				acc.AddFields("ping", fields, tags)
+				return
+			}
+
 			args := p.args(u)
 			totalTimeout := p.timeout() * float64(p.Count)
 			out, err := p.pingHost(totalTimeout, args...)
@@ -167,7 +180,6 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 				// Combine go err + stderr output
 				pendingError = errors.New(strings.TrimSpace(out) + ", " + err.Error())
 			}
-			tags := map[string]string{"url": u}
 			trans, recReply, receivePacket, avg, min, max, err := processPingOutput(out)
 			if err != nil {
 				// fatal error
@@ -175,24 +187,20 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 					errorChannel <- pendingError
 				}
 				errorChannel <- err
-				fields := map[string]interface{}{
-					"errors": 100.0,
-				}
 
+				fields["errors"] = 100.0
 				acc.AddFields("ping", fields, tags)
-
 				return
 			}
 			// Calculate packet loss percentage
 			lossReply := float64(trans-recReply) / float64(trans) * 100.0
 			lossPackets := float64(trans-receivePacket) / float64(trans) * 100.0
-			fields := map[string]interface{}{
-				"packets_transmitted": trans,
-				"reply_received":      recReply,
-				"packets_received":    receivePacket,
-				"percent_packet_loss": lossPackets,
-				"percent_reply_loss":  lossReply,
-			}
+
+			fields["packets_transmitted"] = trans
+			fields["reply_received"] = recReply
+			fields["packets_received"] = receivePacket
+			fields["percent_packet_loss"] = lossPackets
+			fields["percent_reply_loss"] = lossReply
 			if avg > 0 {
 				fields["average_response_ms"] = float64(avg)
 			}

--- a/plugins/inputs/ping/ping_windows_test.go
+++ b/plugins/inputs/ping/ping_windows_test.go
@@ -4,9 +4,10 @@ package ping
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // Windows ping format ( should support multilanguage ?)
@@ -81,6 +82,7 @@ func TestPingGather(t *testing.T) {
 		"average_response_ms": 50.0,
 		"minimum_response_ms": 50.0,
 		"maximum_response_ms": 52.0,
+		"result_code":         0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 
@@ -121,6 +123,7 @@ func TestBadPingGather(t *testing.T) {
 		"reply_received":      0,
 		"percent_packet_loss": 100.0,
 		"percent_reply_loss":  100.0,
+		"result_code":         0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 }
@@ -167,6 +170,7 @@ func TestLossyPingGather(t *testing.T) {
 		"average_response_ms": 115.0,
 		"minimum_response_ms": 114.0,
 		"maximum_response_ms": 119.0,
+		"result_code":         0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 }
@@ -269,6 +273,7 @@ func TestUnreachablePingGather(t *testing.T) {
 		"reply_received":      0,
 		"percent_packet_loss": 75.0,
 		"percent_reply_loss":  100.0,
+		"result_code":         0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 
@@ -315,6 +320,7 @@ func TestTTLExpiredPingGather(t *testing.T) {
 		"reply_received":      0,
 		"percent_packet_loss": 75.0,
 		"percent_reply_loss":  100.0,
+		"result_code":         0,
 	}
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -135,7 +135,7 @@ type Snmp struct {
 	Name   string
 	Fields []Field `toml:"field"`
 
-	connectionCache map[string]snmpConnection
+	connectionCache []snmpConnection
 	initialized     bool
 }
 
@@ -143,6 +143,8 @@ func (s *Snmp) init() error {
 	if s.initialized {
 		return nil
 	}
+
+	s.connectionCache = make([]snmpConnection, len(s.Agents))
 
 	for i := range s.Tables {
 		if err := s.Tables[i].init(); err != nil {
@@ -342,30 +344,36 @@ func (s *Snmp) Gather(acc telegraf.Accumulator) error {
 		return err
 	}
 
-	for _, agent := range s.Agents {
-		gs, err := s.getConnection(agent)
-		if err != nil {
-			acc.AddError(Errorf(err, "agent %s", agent))
-			continue
-		}
-
-		// First is the top-level fields. We treat the fields as table prefixes with an empty index.
-		t := Table{
-			Name:   s.Name,
-			Fields: s.Fields,
-		}
-		topTags := map[string]string{}
-		if err := s.gatherTable(acc, gs, t, topTags, false); err != nil {
-			acc.AddError(Errorf(err, "agent %s", agent))
-		}
-
-		// Now is the real tables.
-		for _, t := range s.Tables {
-			if err := s.gatherTable(acc, gs, t, topTags, true); err != nil {
-				acc.AddError(Errorf(err, "agent %s: gathering table %s", agent, t.Name))
+	var wg sync.WaitGroup
+	for i, agent := range s.Agents {
+		wg.Add(1)
+		go func(i int, agent string) {
+			defer wg.Done()
+			gs, err := s.getConnection(i)
+			if err != nil {
+				acc.AddError(Errorf(err, "agent %s", agent))
+				return
 			}
-		}
+
+			// First is the top-level fields. We treat the fields as table prefixes with an empty index.
+			t := Table{
+				Name:   s.Name,
+				Fields: s.Fields,
+			}
+			topTags := map[string]string{}
+			if err := s.gatherTable(acc, gs, t, topTags, false); err != nil {
+				acc.AddError(Errorf(err, "agent %s", agent))
+			}
+
+			// Now is the real tables.
+			for _, t := range s.Tables {
+				if err := s.gatherTable(acc, gs, t, topTags, true); err != nil {
+					acc.AddError(Errorf(err, "agent %s: gathering table %s", agent, t.Name))
+				}
+			}
+		}(i, agent)
 	}
+	wg.Wait()
 
 	return nil
 }
@@ -568,16 +576,18 @@ func (gsw gosnmpWrapper) Get(oids []string) (*gosnmp.SnmpPacket, error) {
 }
 
 // getConnection creates a snmpConnection (*gosnmp.GoSNMP) object and caches the
-// result using `agent` as the cache key.
-func (s *Snmp) getConnection(agent string) (snmpConnection, error) {
-	if s.connectionCache == nil {
-		s.connectionCache = map[string]snmpConnection{}
-	}
-	if gs, ok := s.connectionCache[agent]; ok {
+// result using `agentIndex` as the cache key.  This is done to allow multiple
+// connections to a single address.  It is an error to use a connection in
+// more than one goroutine.
+func (s *Snmp) getConnection(idx int) (snmpConnection, error) {
+	if gs := s.connectionCache[idx]; gs != nil {
 		return gs, nil
 	}
 
+	agent := s.Agents[idx]
+
 	gs := gosnmpWrapper{&gosnmp.GoSNMP{}}
+	s.connectionCache[idx] = gs
 
 	host, portStr, err := net.SplitHostPort(agent)
 	if err != nil {
@@ -677,7 +687,6 @@ func (s *Snmp) getConnection(agent string) (snmpConnection, error) {
 		return nil, Errorf(err, "setting up connection")
 	}
 
-	s.connectionCache[agent] = gs
 	return gs, nil
 }
 

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -120,7 +120,7 @@ func TestSampleConfig(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, s, *conf.Inputs.Snmp[0])
+	assert.Equal(t, &s, conf.Inputs.Snmp[0])
 }
 
 func TestFieldInit(t *testing.T) {
@@ -251,13 +251,16 @@ func TestSnmpInit_noTranslate(t *testing.T) {
 
 func TestGetSNMPConnection_v2(t *testing.T) {
 	s := &Snmp{
+		Agents:    []string{"1.2.3.4:567", "1.2.3.4"},
 		Timeout:   internal.Duration{Duration: 3 * time.Second},
 		Retries:   4,
 		Version:   2,
 		Community: "foo",
 	}
+	err := s.init()
+	require.NoError(t, err)
 
-	gsc, err := s.getConnection("1.2.3.4:567")
+	gsc, err := s.getConnection(0)
 	require.NoError(t, err)
 	gs := gsc.(gosnmpWrapper)
 	assert.Equal(t, "1.2.3.4", gs.Target)
@@ -265,7 +268,7 @@ func TestGetSNMPConnection_v2(t *testing.T) {
 	assert.Equal(t, gosnmp.Version2c, gs.Version)
 	assert.Equal(t, "foo", gs.Community)
 
-	gsc, err = s.getConnection("1.2.3.4")
+	gsc, err = s.getConnection(1)
 	require.NoError(t, err)
 	gs = gsc.(gosnmpWrapper)
 	assert.Equal(t, "1.2.3.4", gs.Target)
@@ -274,6 +277,7 @@ func TestGetSNMPConnection_v2(t *testing.T) {
 
 func TestGetSNMPConnection_v3(t *testing.T) {
 	s := &Snmp{
+		Agents:         []string{"1.2.3.4"},
 		Version:        3,
 		MaxRepetitions: 20,
 		ContextName:    "mycontext",
@@ -287,8 +291,10 @@ func TestGetSNMPConnection_v3(t *testing.T) {
 		EngineBoots:    1,
 		EngineTime:     2,
 	}
+	err := s.init()
+	require.NoError(t, err)
 
-	gsc, err := s.getConnection("1.2.3.4")
+	gsc, err := s.getConnection(0)
 	require.NoError(t, err)
 	gs := gsc.(gosnmpWrapper)
 	assert.Equal(t, gs.Version, gosnmp.Version3)
@@ -308,15 +314,22 @@ func TestGetSNMPConnection_v3(t *testing.T) {
 }
 
 func TestGetSNMPConnection_caching(t *testing.T) {
-	s := &Snmp{}
-	gs1, err := s.getConnection("1.2.3.4")
+	s := &Snmp{
+		Agents: []string{"1.2.3.4", "1.2.3.5", "1.2.3.5"},
+	}
+	err := s.init()
 	require.NoError(t, err)
-	gs2, err := s.getConnection("1.2.3.4")
+	gs1, err := s.getConnection(0)
 	require.NoError(t, err)
-	gs3, err := s.getConnection("1.2.3.5")
+	gs2, err := s.getConnection(0)
+	require.NoError(t, err)
+	gs3, err := s.getConnection(1)
+	require.NoError(t, err)
+	gs4, err := s.getConnection(2)
 	require.NoError(t, err)
 	assert.True(t, gs1 == gs2)
 	assert.False(t, gs2 == gs3)
+	assert.False(t, gs3 == gs4)
 }
 
 func TestGosnmpWrapper_walk_retry(t *testing.T) {
@@ -560,11 +573,11 @@ func TestGather(t *testing.T) {
 			},
 		},
 
-		connectionCache: map[string]snmpConnection{
-			"TestGather": tsc,
+		connectionCache: []snmpConnection{
+			tsc,
 		},
+		initialized: true,
 	}
-
 	acc := &testutil.Accumulator{}
 
 	tstart := time.Now()
@@ -607,9 +620,10 @@ func TestGather_host(t *testing.T) {
 			},
 		},
 
-		connectionCache: map[string]snmpConnection{
-			"TestGather": tsc,
+		connectionCache: []snmpConnection{
+			tsc,
 		},
+		initialized: true,
 	}
 
 	acc := &testutil.Accumulator{}


### PR DESCRIPTION
This processor objective is to provide the possibility to pick the top k metrics from a set of metrics.

The pluging uses:
 - Selectors to pick the metrics that will be filtered
 - A group by clause to group the metrics based on metric names and tags
 - A list of fields
 - An aggregator function to agreggate each field of the grouped metrics
 
Once the aggregations for each group are calculated, the plugin orders the groups by each aggregation and returns all the metrics of each group in the top k spots

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
